### PR TITLE
extract toolbar in its own module

### DIFF
--- a/kanban-fire/src/app/app.component.css
+++ b/kanban-fire/src/app/app.component.css
@@ -25,14 +25,6 @@
     opacity: 0.2;
 }
 
-mat-toolbar > span {
-    margin-left: 12px;
-}
-
-mat-toolbar {
-    margin-bottom: 30px;
-}
-
 .cdk-drag-placeholder {
     opacity: 0;
 }

--- a/kanban-fire/src/app/app.component.html
+++ b/kanban-fire/src/app/app.component.html
@@ -1,7 +1,7 @@
-<mat-toolbar color="primary">
-  <mat-icon>local_fire_department</mat-icon>
-  <span>Kanban Fire</span>
-</mat-toolbar>
+<app-toolbar
+  [iconName]="'local_fire_department'"
+  [title]="'Kanban Fire'"
+></app-toolbar>
 
 <div class="content-wrapper">
   <button (click)="newTask()" mat-button>

--- a/kanban-fire/src/app/app.component.spec.ts
+++ b/kanban-fire/src/app/app.component.spec.ts
@@ -4,13 +4,13 @@ import { TaskComponent } from './task/task.component';
 
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
-import { MatToolbarModule } from '@angular/material/toolbar';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { MatDialogModule } from '@angular/material/dialog';
 import { getFirestore, provideFirestore } from '@angular/fire/firestore';
 import { initializeApp, provideFirebaseApp } from '@angular/fire/app';
 import { environment } from 'src/environments/environment';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { ToolbarModule } from './toolbar/toolbar.module';
 
 
 describe('AppComponent', () => {
@@ -25,9 +25,9 @@ describe('AppComponent', () => {
       MatCardModule,
       MatIconModule,
       MatProgressSpinnerModule,
-      MatToolbarModule,
       provideFirebaseApp(() => initializeApp(environment.firebase)),
       provideFirestore(() => getFirestore()),
+      ToolbarModule
     ]
   }));
 

--- a/kanban-fire/src/app/app.module.ts
+++ b/kanban-fire/src/app/app.module.ts
@@ -9,7 +9,6 @@ import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'; 
-import { MatToolbarModule } from '@angular/material/toolbar';
 import { NgModule } from '@angular/core';
 
 import { AppComponent } from './app.component';
@@ -18,6 +17,7 @@ import { TaskComponent } from './task/task.component';
 import { TaskDialogComponent } from './task-dialog/task-dialog.component';
 import { FormsModule } from '@angular/forms';
 import { environment } from 'src/environments/environment';
+import { ToolbarModule } from './toolbar/toolbar.module';
 
 @NgModule({
   declarations: [
@@ -35,10 +35,10 @@ import { environment } from 'src/environments/environment';
     MatCardModule,
     MatIconModule,
     MatInputModule,
-    MatProgressSpinnerModule,    
-    MatToolbarModule,
+    MatProgressSpinnerModule,
     provideFirebaseApp(() => initializeApp(environment.firebase)),
     provideFirestore(() => getFirestore()),
+    ToolbarModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/kanban-fire/src/app/toolbar/toolbar.module.ts
+++ b/kanban-fire/src/app/toolbar/toolbar.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ToolbarComponent } from './toolbar/toolbar.component';
+import { MatIconModule } from '@angular/material/icon';
+import { MatToolbarModule } from '@angular/material/toolbar';
+
+
+
+@NgModule({
+  declarations: [
+    ToolbarComponent
+  ],
+  imports: [
+    CommonModule,
+    MatIconModule,
+    MatToolbarModule,    
+  ],
+  exports: [
+    ToolbarComponent
+  ]
+})
+export class ToolbarModule { }

--- a/kanban-fire/src/app/toolbar/toolbar/toolbar.component.css
+++ b/kanban-fire/src/app/toolbar/toolbar/toolbar.component.css
@@ -1,0 +1,7 @@
+mat-toolbar > span {
+    margin-left: 12px;
+}
+
+mat-toolbar {
+    margin-bottom: 30px;
+}

--- a/kanban-fire/src/app/toolbar/toolbar/toolbar.component.html
+++ b/kanban-fire/src/app/toolbar/toolbar/toolbar.component.html
@@ -1,0 +1,4 @@
+<mat-toolbar color="primary">
+  <mat-icon>{{ iconName }}</mat-icon>
+  <span>{{ title }}</span>
+</mat-toolbar>

--- a/kanban-fire/src/app/toolbar/toolbar/toolbar.component.spec.ts
+++ b/kanban-fire/src/app/toolbar/toolbar/toolbar.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ToolbarComponent } from './toolbar.component';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatIconModule } from '@angular/material/icon';
+
+describe('ToolbarComponent', () => {
+  let component: ToolbarComponent;
+  let fixture: ComponentFixture<ToolbarComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ToolbarComponent],
+      imports: [MatIconModule, MatToolbarModule]
+    });
+    fixture = TestBed.createComponent(ToolbarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/kanban-fire/src/app/toolbar/toolbar/toolbar.component.ts
+++ b/kanban-fire/src/app/toolbar/toolbar/toolbar.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-toolbar',
+  templateUrl: './toolbar.component.html',
+  styleUrls: ['./toolbar.component.css']
+})
+export class ToolbarComponent {
+  @Input() iconName = '';
+  @Input() title = '';
+}


### PR DESCRIPTION
toolbar is extracted in its own `feature`/`ui` `module`. Let's call `ui` as there is no data really coming into `toolbar.module`, except a couple of string `Input`s.
If `toolbar.module` is going to make `http` calls, it will be `feature` module.
`app` depends on less: `MatToolbarModule` from `Angular` `Material` dependency is moved into `toolbar.module` together with styles, etc...
`MatIconModule` is going to be moved with next module extraction: `feature-swim-lanes.module`